### PR TITLE
integrate vernal into pipeline

### DIFF
--- a/Pipeline/controllers/PipelineController.py
+++ b/Pipeline/controllers/PipelineController.py
@@ -1,7 +1,9 @@
 from flask import abort
 from .BayesPairingController import BayesPairing
 from .RnaMigosController import RnaMigos
+from .VernalController import Vernal
 import json
+
 
 class Pipeline:
 
@@ -17,6 +19,7 @@ class Pipeline:
         bp_input = files.get("bp_input")
         vernal = arguments.get("vernal", default=1, type=int)
         rnamigos = arguments.get("rnamigos", default=1, type=int)
+        dataset = arguments.get("dataset", default="ALL", type=str)
 
         arguments = arguments.to_dict()
         arguments['get_graphs'] = 1
@@ -29,17 +32,24 @@ class Pipeline:
             return bp_result.status_code, bp_result.json()
 
         bp_data = bp_result.json()
-        motifs = bp_data.get("motif_graphs")
+        rep_graphs = str(bp_data.get("motif_graphs"))
         bp_data.pop("motif_graphs", None)
 
+        if rnamigos:
+            rnamigos_result = RnaMigos.rnamigos_string(rep_graphs)
+            if not rnamigos_result:
+                return rnamigos_result.status_code, rnamigos_result.json()
 
-        if rnamigos == 1:
-            rnamigos_result = RnaMigos.rnamigos_string(str(motifs))
-            if rnamigos_result.status_code == 200:
-                rnamigos_data = rnamigos_result.json()
-                bp_data["rnamigos_result"] = rnamigos_data
-                return rnamigos_result.status_code, bp_data
-        
+            bp_data["rnamigos_result"] = rnamigos_result.json()
+
+        if vernal:
+            vernal_result = Vernal.vernal_similarity_function(
+                rep_graphs, dataset)
+            if not vernal_result:
+                return vernal_result.status_code, vernal_result.json()
+
+            bp_data["similar_motifs"] = vernal_result.json()["vernalOutput"]
+
         return bp_result.status_code, bp_data
 
     @staticmethod
@@ -53,6 +63,7 @@ class Pipeline:
         '''
         vernal = arguments.get("vernal", default=1, type=int)
         rnamigos = arguments.get("rnamigos", default=1, type=int)
+        dataset = arguments.get("dataset", default="ALL", type=str)
 
         arguments = arguments.to_dict()
         arguments['get_graphs'] = 1
@@ -65,14 +76,22 @@ class Pipeline:
             return bp_result.status_code, bp_result.json()
 
         bp_data = bp_result.json()
-        motifs = bp_data.get("motif_graphs")
+        rep_graphs = str(bp_data.get("motif_graphs"))
         bp_data.pop("motif_graphs", None)
 
-        if rnamigos == 1:
-            rnamigos_result = RnaMigos.rnamigos_string(str(motifs))
-            if rnamigos_result.status_code == 200:
-                rnamigos_data = rnamigos_result.json()
-                bp_data["rnamigos_result"] = rnamigos_data
-                return rnamigos_result.status_code, bp_data
-        
+        if rnamigos:
+            rnamigos_result = RnaMigos.rnamigos_string(rep_graphs)
+            if not rnamigos_result:
+                return rnamigos_result.status_code, rnamigos_result.json()
+
+            bp_data["rnamigos_result"] = rnamigos_result.json()
+
+        if vernal:
+            vernal_result = Vernal.vernal_similarity_function(
+                rep_graphs, dataset)
+            if not vernal_result:
+                return vernal_result.status_code, vernal_result.json()
+
+            bp_data["similar_motifs"] = vernal_result.json()["vernalOutput"]
+
         return bp_result.status_code, bp_data

--- a/Pipeline/controllers/VernalController.py
+++ b/Pipeline/controllers/VernalController.py
@@ -6,5 +6,5 @@ from services.Vernal import *
 class Vernal:
 
     @staticmethod
-    def vernalSimilarityFunction(representative_graphs, dataset):
-        return vernalSimilarityFunction(representative_graphs, dataset)
+    def vernal_similarity_function(representative_graphs, dataset):
+        return vernal_similarity_function(representative_graphs, dataset)

--- a/Pipeline/services/Vernal.py
+++ b/Pipeline/services/Vernal.py
@@ -4,7 +4,7 @@
 import requests 
 URL = "http://0.0.0.0:5003/"
 
-def vernalSimilarityFunction(representative_graphs, dataset):
+def vernal_similarity_function(representative_graphs, dataset):
 
     data = {"graphs": str(representative_graphs), "dataset": dataset}
     headers = {}


### PR DESCRIPTION
- Integrates VeRNAl into the pipeline
- Renames VeRNal's service + controller methods for consistency 
- Clean up to RNAMigos to be consistent with VeRNAl. Checking for 200 is not necessary since we can just check if the response itself is valid i.e. ```if (result)```. Moreover, checks for an error first and returns it. Otherwise, simply adds the RNAMigos result to the final output dictionary.

Confirmed to be working with sample output available on the doc website. Note that if you want to run it yourselves, you first need to pull this [PR](https://github.com/TeamW-P/VeRNAl/pull/8) from VeRNAl (assuming it hasn't been merged yet).
